### PR TITLE
bug: customer field naming on quotations, add null checks

### DIFF
--- a/taxjar_erpnext/taxjar_erpnext/taxjar_erpnext.py
+++ b/taxjar_erpnext/taxjar_erpnext/taxjar_erpnext.py
@@ -549,12 +549,21 @@ def check_sales_tax_exemption(doc, taxjar_account):
 	"""
 	TAX_ACCOUNT_HEAD = taxjar_account.tax_account_head
 	
+	# Get customer name - Quotations use party_name, Sales Order/Invoice use customer
+	customer_name = getattr(doc, "customer", None) or getattr(doc, "party_name", None)
+	
+	# Check document-level exemption first, then customer-level exemption
 	sales_tax_exempted = (
 		hasattr(doc, "exempt_from_sales_tax")
 		and doc.exempt_from_sales_tax
-		or frappe.db.has_column("Customer", "exempt_from_sales_tax")
-		and frappe.db.get_value("Customer", doc.customer, "exempt_from_sales_tax")
 	)
+	
+	# If not exempt at document level, check customer level
+	if not sales_tax_exempted and customer_name:
+		if frappe.db.has_column("Customer", "exempt_from_sales_tax"):
+			sales_tax_exempted = frappe.db.get_value(
+				"Customer", customer_name, "exempt_from_sales_tax"
+			)
 	
 	if sales_tax_exempted:
 		for tax in doc.taxes:

--- a/taxjar_erpnext/taxjar_erpnext/taxjar_erpnext.py
+++ b/taxjar_erpnext/taxjar_erpnext/taxjar_erpnext.py
@@ -549,8 +549,15 @@ def check_sales_tax_exemption(doc, taxjar_account):
 	"""
 	TAX_ACCOUNT_HEAD = taxjar_account.tax_account_head
 	
-	# Get customer name - Quotations use party_name, Sales Order/Invoice use customer
-	customer_name = getattr(doc, "customer", None) or getattr(doc, "party_name", None)
+	# Get customer name:
+	# - Sales Order/Invoice: use customer field directly
+	# - Quotation: use party_name only if quotation_to == "Customer" (not Lead)
+	customer_name = getattr(doc, "customer", None)
+	if not customer_name and doc.doctype == "Quotation":
+		# Only treat party_name as a Customer if quotation_to is "Customer"
+		quotation_to = getattr(doc, "quotation_to", None)
+		if quotation_to == "Customer":
+			customer_name = getattr(doc, "party_name", None)
 	
 	# Check document-level exemption first, then customer-level exemption
 	sales_tax_exempted = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes sales tax exemption checks to safely resolve the customer on quotations and avoid null/column errors.
> 
> - Updates `check_sales_tax_exemption` to derive `customer_name` for `Quotation` from `party_name` only when `quotation_to == "Customer"`; otherwise does not treat as a customer
> - Splits document-level `exempt_from_sales_tax` check from customer-level lookup with explicit null and `has_column` guards
> - Preserves behavior of zeroing the TaxJar tax row and recalculating totals when exempt
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77ef83862c762fe63aa75d4035bb3cecc4dbf7ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->