### PR TITLE
chore: adjust tax estimation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ TaxJar Integration connects your ERPNext instance with [TaxJar](https://www.taxj
 - Optional non-nexus calculations.
 - Calculate estimated sales tax for Quotations even in states without nexus
 - Uses TaxJar's `rates_for_location` API for accurate location-based rates
-- Tax rows clearly labeled as "Estimated Sales Tax - {STATE} (Nexus Not Established)"
+- Tax rows labeled as "Estimated Sales Tax" to distinguish from regular tax calculations
 - Ensures quotes never undercharge (estimates may be higher than actual tax due to exemptions not being applied)
 - _Enable via "Calculate Estimated Tax for All States" in TaxJar Account settings_
 

--- a/taxjar_erpnext/taxjar_erpnext/taxjar_erpnext.py
+++ b/taxjar_erpnext/taxjar_erpnext/taxjar_erpnext.py
@@ -444,11 +444,8 @@ def set_sales_tax(doc, method):
 		return
 	
 	# Determine description based on source
-	if use_rate_fallback:
-		destination_state = tax_dict.get("to_state", "")
-		description = f"Estimated Sales Tax - {destination_state} (Nexus Not Established)"
-	elif is_non_nexus_quote:
-		description = "Estimated Sales Tax (Nexus Not Established)"
+	if use_rate_fallback or is_non_nexus_quote:
+		description = "Estimated Sales Tax"
 	else:
 		description = "Sales Tax"
 	


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns UI text and docs for non-nexus quotation estimates.
> 
> - In `set_sales_tax`, tax row `description` now uses `"Estimated Sales Tax"` whenever `use_rate_fallback` or non-nexus quotation applies; otherwise `"Sales Tax"`
> - README updated to state tax rows are labeled as `"Estimated Sales Tax"`, removing state-specific wording
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43d515b21a3e235e70206e80a2ed4322c788cc18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->